### PR TITLE
Init ~user/.ssh and authorized_keys if not there

### DIFF
--- a/keyex
+++ b/keyex
@@ -336,6 +336,16 @@ class KeyexTarget(object):
         else:
             keys = [key]
 
+        # Init ~user/.ssh and authorized_keys if needed
+        self.run_command("mkdir -p ~{user}/.ssh/".format(
+                            user=self.user))
+        self.run_command("chmod 0700 ~{user}/.ssh/".format(
+                            user=self.user))
+        self.run_command("touch ~{user}/.ssh/authorized_keys".format(
+                            user=self.user))
+        self.run_command("chmod 0600 ~{user}/.ssh/authorized_keys".format(
+                            user=self.user))
+
         # Since we may need to sudo to read the file, just use cat
         authorized_keys = []
         try:


### PR DESCRIPTION
Fixes this kind of issue when `~user/.ssh` and/or `~user/.ssh/authorized_keys` do not exist:

```console
INFO: Sending public key of postgres@demo-1 to postgres@demo-2
DEBUG: Command: cat ~postgres/.ssh/authorized_keys
DEBUG: Command execution failed: rc=1
DEBUG: stderr:
DEBUG: cat: /var/lib/pgsql/.ssh/authorized_keys: No such file or directory
DEBUG: Command: sh -c 'cat >> ~postgres/.ssh/authorized_keys'
Traceback (most recent call last):
  File "./keyex", line 580, in <module>
    main()
  File "./keyex", line 552, in main
    dst.authorize_key(src_pubkey)
  File "./keyex", line 382, in authorize_key
    "Unable to append key to authorized_keys file"
__main__.KeyexException: Unable to append key to authorized_keys file
```